### PR TITLE
fix shared build of libccnet on mingw64

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -171,6 +171,27 @@ AC_CHECK_LIB(pthread, pthread_create, [echo "found library pthread"], AC_MSG_ERR
 AC_CHECK_LIB(sqlite3, sqlite3_open,[echo "found library sqlite3"] , AC_MSG_ERROR([*** Unable to find sqlite3 library]), )
 AC_CHECK_LIB(crypto, SHA1_Init, [echo "found library crypto"], AC_MSG_ERROR([*** Unable to find openssl crypto library]), )
 
+PTHREAD_CFLAGS=-pthread
+PTHREAD_LIBS=-lpthread
+has_winpthread=false
+if test "$bwin32" = "true"; then
+  has_winpthread=false
+  dnl this will tell us if the implementation of pthread is winpthread
+  AC_CHECK_LIB(winpthread, pthread_create, has_winpthread=true,
+               [echo "found library winpthread"], )
+  PTHREAD_CFLAGS=-pthread
+  PTHREAD_LIBS=-lwinpthread
+fi
+
+dnl Saddly, the old mingw gcc doesn't support -pthread flag
+if test "$bwin32" = "true" -a "$has_winpthread" != "true"; then
+  PTHREAD_CFLAGS=
+  PTHREAD_LIBS=-lpthread
+fi
+
+AC_SUBST(PTHREAD_CFLAGS)
+AC_SUBST(PTHREAD_LIBS)
+
 dnl Do we need to use AX_LIB_SQLITE3 to check sqlite?
 dnl AX_LIB_SQLITE3
 

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -30,7 +30,7 @@ noinst_HEADERS = buffer.h \
 ccnetincludedir = $(includedir)/ccnet
 ccnetinclude_DATA = ccnet-object.h
 
-libccnet_la_CPPFLAGS = $(AM_CPPFLAGS) -DCCNET_LIB
+libccnet_la_CPPFLAGS = $(AM_CPPFLAGS) -DCCNET_LIB @PTHREAD_CFLAGS@
 
 libccnet_la_SOURCES = ccnet-client.c packet-io.c libccnet_utils.c \
 	message.c proc-factory.c \
@@ -47,7 +47,7 @@ libccnet_la_SOURCES = ccnet-client.c packet-io.c libccnet_utils.c \
 EXTRA_DIST = ccnetobj.vala rpc_table.py
 
 libccnet_la_LDFLAGS = -no-undefined -version-info 0:0:0
-libccnet_la_LIBADD = -lpthread @GLIB2_LIBS@  @GOBJECT_LIBS@ @SSL_LIBS@ @LIB_GDI32@ \
+libccnet_la_LIBADD = @PTHREAD_LIBS@ @GLIB2_LIBS@ @GOBJECT_LIBS@ @SSL_LIBS@ @LIB_GDI32@ \
 				     @LIB_UUID@ @LIB_WS32@ @LIB_PSAPI@ -lsqlite3 \
 					 @LIBEVENT_LIBS@ @SEARPC_LIBS@ @LIB_SHELL32@
 


### PR DESCRIPTION
libtool complains that newer mingw64 environment don't have a real library
-lpthread, so it doesn't create a shared library while it deals with
-no-undefined

TL'DR: the de facto way of building pthread program is passing -pthread, but old
mingw gcc compiler doesn't support it. the patch addes some workarounds for both
situations.

more details:

        *** The inter-library dependencies that have been dropped here will be
        *** automatically added whenever a program is linked with this library
        *** or is declared to -dlopen it.

        *** Since this library must not contain undefined symbols,
        *** because either the platform does not support them or
        *** it was explicitly requested with -no-undefined,
        *** libtool will only create a static version of it.

more information:

        undefined reference to pthread_create in Linux
        https://stackoverflow.com/questions/1662909/undefined-reference-to-pthread-create-in-linux?answertab=votes#tab-top

        -pthread : Adds support for multithreading with the pthreads library. This option sets flags for both the preprocessor and linker.
        http://linux.die.net/man/1/gcc

        POSIX Threads Programming
        https://computing.llnl.gov/tutorials/pthreads/#Compiling