### PR TITLE
Synchronize arguments in ccnet_session_prepare calls

### DIFF
--- a/net/cluster/server.c
+++ b/net/cluster/server.c
@@ -256,12 +256,12 @@ main (int argc, char **argv)
 
     event_init ();
     evdns_init ();
-    if (ccnet_session_prepare(session, config_dir) < 0) {
+    if (ccnet_session_prepare(session, NULL, config_dir, FALSE) < 0) {
         fputs ("Error: failed to start ccnet session, "
                "see log file for the detail.\n", stderr);
         return -1;
     }
-    if (ccnet_session_prepare(inner_session, cluster_config_dir) < 0) {
+    if (ccnet_session_prepare(inner_session, NULL, cluster_config_dir, FALSE) < 0) {
         fputs ("Error: failed to start cluster ccnet session, "
                "see log file for the detail.\n", stderr);
         return -1;


### PR DESCRIPTION
This was probably missed, when the number of arguments in ccnet_session_prepare changed.

I'm not too sure if the test_config argument should be TRUE or FALSE, so please take extra care of that, if you intend to merge.

Thanks!