### PR TITLE
curl: avoid race conditions with crypto-functionality by using the CRYPTO_* functions from openssl

### DIFF
--- a/net/common/curl-init.c
+++ b/net/common/curl-init.c
@@ -1,0 +1,42 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+#include <curl/curl.h>
+#include <openssl/crypto.h>
+#include <pthread.h>
+
+#include "curl-init.h"
+
+pthread_mutex_t* curl_locks = NULL;
+
+void ccnet_curl_locking_callback(int mode, int n, const char* file, int line)
+{
+    if (mode & CRYPTO_LOCK) {
+        pthread_mutex_lock (&curl_locks[n]);
+    } else {
+        pthread_mutex_unlock (&curl_locks[n]);
+    }
+}
+
+void ccnet_curl_init()
+{
+    int i;
+    curl_locks = malloc (sizeof(pthread_mutex_t) * CRYPTO_num_locks());
+    for (i = 0; i < CRYPTO_num_locks(); ++i) {
+        pthread_mutex_init (&curl_locks[i], NULL);
+    }
+
+    CRYPTO_set_id_callback (pthread_self);
+    CRYPTO_set_locking_callback (ccnet_curl_locking_callback);
+}
+
+void ccnet_curl_deinit()
+{
+    int i;
+    CRYPTO_set_id_callback (0);
+    CRYPTO_set_locking_callback (0);
+
+    for (i = 0; i < CRYPTO_num_locks(); ++i) {
+        pthread_mutex_destroy (&curl_locks[i]);
+    }
+    free (curl_locks);
+}

--- a/net/common/curl-init.h
+++ b/net/common/curl-init.h
@@ -1,0 +1,9 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+#ifndef __CURL_INIT_H__
+#define __CURL_INIT_H__
+
+void ccnet_curl_init(void);
+void ccnet_curl_deinit(void);
+
+#endif

--- a/net/daemon/Makefile.am
+++ b/net/daemon/Makefile.am
@@ -52,7 +52,8 @@ common_headers = ../common/algorithms.h \
 	../common/processor.h \
 	../common/peermgr-message.h \
 	../common/rpc-service.h \
-	../common/ccnet-db.h
+	../common/ccnet-db.h \
+	../common/curl-init.h
 
 # ../common/group.h
 # ../common/group-mgr.h \
@@ -86,7 +87,8 @@ common_srcs = ../common/session.c ../common/peer-mgr.c ../common/packet-io.c \
 	../common/processors/sendsessionkey-proc.c \
 	../common/processors/recvsessionkey-proc.c \
 	../common/processors/sendsessionkey-v2-proc.c \
-	../common/processors/recvsessionkey-v2-proc.c
+	../common/processors/recvsessionkey-v2-proc.c \
+	../common/curl-init.c
 
 ccnet_SOURCES = ccnet-daemon.c \
 	daemon-session.c \

--- a/net/daemon/ccnet-daemon.c
+++ b/net/daemon/ccnet-daemon.c
@@ -16,6 +16,7 @@
 #include "daemon-session.h"
 #include "rpc-service.h"
 #include "log.h"
+#include "curl-init.h"
 
 #ifndef SEAFILE_CLIENT_VERSION
 #define SEAFILE_CLIENT_VERSION PACKAGE_VERSION
@@ -217,12 +218,14 @@ main (int argc, char **argv)
     setSigHandlers();
 #endif
    
+    ccnet_curl_init();
     ccnet_session_start (session);
     ccnet_start_rpc(session);
 
     /* actually enter the event loop */
     /* event_set_log_callback (logFunc); */
     event_dispatch ();
+    ccnet_curl_deinit();
 
     return 0;
 }

--- a/net/server/Makefile.am
+++ b/net/server/Makefile.am
@@ -60,7 +60,8 @@ common_headers =
 	../common/processor.h \
 	../common/peermgr-message.h \
 	../common/rpc-service.h \
-	../common/ccnet-db.h
+	../common/ccnet-db.h \
+	../common/curl-init.h
 
 
 noinst_HEADERS = $(common_headers) \
@@ -93,7 +94,8 @@ common_srcs = ../common/ccnet-db.c \
 	../common/processors/sendsessionkey-proc.c \
 	../common/processors/recvsessionkey-proc.c \
 	../common/processors/sendsessionkey-v2-proc.c \
-	../common/processors/recvsessionkey-v2-proc.c
+	../common/processors/recvsessionkey-v2-proc.c \
+	../common/curl-init.c
 
 ccnet_server_SOURCES = ccnet-server.c \
 	server-session.c user-mgr.c group-mgr.c org-mgr.c \

--- a/net/server/ccnet-server.c
+++ b/net/server/ccnet-server.c
@@ -16,6 +16,7 @@
 #include "user-mgr.h"
 #include "rpc-service.h"
 #include "log.h"
+#include "curl-init.h"
 
 char *pidfile = NULL;
 CcnetSession  *session;
@@ -331,11 +332,13 @@ main (int argc, char **argv)
     setSigHandlers();
 #endif
 
+    ccnet_curl_init();
     ccnet_session_start (session);
     ccnet_start_rpc(session);
 
     /* actually enter the event loop */
     event_dispatch ();
+    ccnet_curl_deinit();
 
     return 0;
 }


### PR DESCRIPTION
Same patch as in https://github.com/haiwen/seafile/pull/1538, not sure if it is needed in ccnet too, but it looks like the same problem could occur here also.