### PR TITLE
 Add support for PKG_CONFIG_PATH/PKG_CONFIG_LIBDIR env vars for libcrypto and libssl

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -6,6 +6,7 @@ AM_CPPFLAGS = @GLIB2_CFLAGS@ -I$(top_srcdir)/include \
 	-DG_LOG_DOMAIN=\"Ccnet\" \
 	@SEARPC_CFLAGS@ \
 	@MSVC_CFLAGS@ \
+	@SSL_CFLAGS@ \
 	-Wall
 
 BUILT_SOURCES = gensource
@@ -29,7 +30,7 @@ noinst_HEADERS = buffer.h \
 ccnetincludedir = $(includedir)/ccnet
 ccnetinclude_DATA = ccnet-object.h
 
-libccnet_la_CPPFLAGS = $(AM_CPPFLAGS) -DCCNET_LIB @PTHREAD_CFLAGS@
+libccnet_la_CPPFLAGS = $(AM_CPPFLAGS) -DCCNET_LIB @PTHREAD_CFLAGS@ @SSL_CFLAGS@
 
 libccnet_la_SOURCES = ccnet-client.c packet-io.c libccnet_utils.c \
 	message.c proc-factory.c \

--- a/net/daemon/Makefile.am
+++ b/net/daemon/Makefile.am
@@ -7,6 +7,7 @@ AM_CPPFLAGS = @GLIB2_CFLAGS@ @GOBJECT_CFLAGS@ \
 	-I$(top_builddir)/include \
 	-I$(top_builddir)/lib \
 	@SEARPC_CFLAGS@ \
+	@SSL_CFLAGS@ \
 	-Wall
 
 bin_PROGRAMS = ccnet


### PR DESCRIPTION
This enables support for compiling ccnet using an OpenSSL version installed outside the system's default prefix. Until ccnet supports openssl 1.1.0, this is required to compile for example on Archlinux where the current openssl 1.0.2 package will soon be upgraded to 1.1.0, and the future 1.0.2 package's files will go into /usr/lib/openssl-1.0.

To use this, execute `export PKG_CONFIG_PATH=/usr/lib/openssl-1.0/lib/pkgconfig` prior to running `autogen.sh`.